### PR TITLE
Removed PaneButtonGrid in NavigationView Style

### DIFF
--- a/dev/NavigationView/TestUI/NavigationViewRS3Page.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewRS3Page.xaml
@@ -214,7 +214,6 @@
                                     <VisualState x:Name="TitleBarVisible" />
                                     <VisualState x:Name="TitleBarCollapsed">
                                         <VisualState.Setters>
-                                            <Setter Target="PaneButtonGrid.Margin" Value="0,32,0,0"/>
                                             <Setter Target="PaneContentGrid.Margin" Value="0,32,0,0"/>
                                         </VisualState.Setters>
                                     </VisualState>


### PR DESCRIPTION
Removed PaneButtonGrid.Margin in the VisualState Setters for the UWP default NavigationView Style.
PaneButtonGrid does not exist in the NavigationView template and in the code behind of the control.